### PR TITLE
Add test to demo dealing with multiple sessions

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -5,11 +5,11 @@ const tasks = require('./cypress/support/tasks')
 module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost/',
+    env: { hideXhr: true },
     setupNodeEvents (on, config) {
       esbuildPreprocessor(on)
       tasks(on)
       return config
     }
-  },
-  fixturesFolder: false
+  }
 })

--- a/cypress/e2e/gui/index.cy.js
+++ b/cypress/e2e/gui/index.cy.js
@@ -19,6 +19,7 @@ import './project/issueBoard.cy'
 import './project/issueMilestone.cy'
 import './project/labelAnIssue.cy'
 import './project/reopenClosedIssue.cy'
+import './project/multipleUsersInAnProject.cy.js'
 import './authentication/loginAsNonDefaultUser.cy'
 
 // Teardown - Delete access token(s)

--- a/cypress/e2e/gui/project/commentOnIssue.cy.js
+++ b/cypress/e2e/gui/project/commentOnIssue.cy.js
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker/locale/en'
 
-describe('Comments on an Issue', () => {
+describe('Comment on an Issue', () => {
   beforeEach(() => {
     cy.api_deleteProjects()
     cy.sessionLogin()

--- a/cypress/e2e/gui/project/multipleUsersInAnProject.cy.js
+++ b/cypress/e2e/gui/project/multipleUsersInAnProject.cy.js
@@ -1,0 +1,73 @@
+const newUser = require('../../../fixtures/sampleUser')
+const { username: newUserName, password: newUserPassword } = newUser
+const defaultUser = Cypress.env('user_name')
+
+describe('Project with multiple users', () => {
+  beforeEach(() => {
+    cy.log('--- Pre-conditions ---')
+    cy.log('1. Delete all users and projects to start in a clean state')
+    cy.deleteAllUsersButRoot()
+    cy.api_deleteProjects()
+    cy.log('2. Create a brand new user')
+    cy.api_createUser(newUser)
+    cy.log(`3. Create a new issue (and by consequence a new project) for the ${defaultUser} user`)
+    cy.api_createIssue()
+      .its('body.iid')
+      .as('issueIid')
+    cy.log(`4. Sign in as ${defaultUser}`)
+    cy.signInAsDefaultUser()
+    cy.log(`5. Add the new user to the ${defaultUser} user's project`)
+    cy.api_getAllProjects().as('projects')
+    cy.get('@projects')
+      .its('body[0].name')
+      .as('projectName')
+      .then(projectName => cy.gui_addUserToProject(newUser, projectName))
+    cy.log('--- End of pre-conditions ---')
+  })
+
+  it('users reply to each other in an issue', () => {
+    cy.log(`1. Visit the issue as ${defaultUser} and comment on it`)
+    cy.visitIssue()
+    cy.gui_commentOnIssue(`Hi @${newUserName}, what do you think?`)
+
+    cy.log(`2. Sign in as ${newUserName}, visit the issue, and reply to the comment`)
+    cy.signInAsNewUser()
+    cy.visitIssue()
+    cy.assertCommentIsVisible('what do you think?')
+    cy.gui_commentOnIssue(`Hey, @${defaultUser}, it looks good to me.`)
+
+    cy.log(`3. Sign in as ${defaultUser}, visit the issue, and reply to the new comment`)
+    cy.signInAsDefaultUser()
+    cy.visitIssue()
+    cy.assertCommentIsVisible('looks good to me.')
+    cy.gui_commentOnIssue('Great, thanks!')
+
+    cy.log(`4. Sign in as ${newUserName}, visit the issue, and reply to the newest comment`)
+    cy.signInAsNewUser()
+    cy.visitIssue()
+    cy.assertCommentIsVisible('Great, thanks!')
+    cy.gui_commentOnIssue('You are welcome!')
+
+    cy.log(`5. Sign in as ${defaultUser}, visit the issue, and see the last comment`)
+    cy.signInAsDefaultUser()
+    cy.visitIssue()
+    cy.assertCommentIsVisible('You are welcome!')
+  })
+})
+
+Cypress.Commands.add('visitIssue', function () {
+  const { projectName, issueIid } = this
+  cy.visit(`${defaultUser}/${projectName}/issues/${issueIid}`)
+})
+
+Cypress.Commands.add('signInAsDefaultUser', () => {
+  cy.sessionLogin()
+})
+
+Cypress.Commands.add('signInAsNewUser', () => {
+  cy.sessionLogin(newUserName, newUserPassword)
+})
+
+Cypress.Commands.add('assertCommentIsVisible', comment => {
+  cy.contains('.timeline-content', comment).should('be.visible')
+})

--- a/cypress/fixtures/sampleUser.json
+++ b/cypress/fixtures/sampleUser.json
@@ -1,0 +1,7 @@
+{
+  "email": "john-doe@example.com",
+  "name": "John Doe",
+  "username": "johndoe",
+  "password": "53cR37-p@s5W0rd",
+  "skip_confirmation": true
+}

--- a/cypress/support/commands/gui_commands.js
+++ b/cypress/support/commands/gui_commands.js
@@ -144,3 +144,18 @@ Cypress.Commands.add('gui_createFile', file => {
   cy.get('#editor').type(file.content)
   cy.get('.qa-commit-button').click()
 })
+
+Cypress.Commands.add('gui_addUserToProject', ({ username }, project) => {
+  cy.visit(`${Cypress.env('user_name')}/${project}/-/project_members`)
+  cy.contains('label', 'GitLab member or Email address')
+    .next()
+    .type(`@${username}`)
+  cy.contains('li', `@${username}`)
+    .should('be.visible')
+    .click()
+  cy.get('.qa-add-member-button').click()
+  cy.contains('.flash-notice', 'Users were successfully added.')
+    .should('be.visible')
+  cy.contains('.qa-members-list', `@${username}`)
+    .should('be.visible')
+})

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,3 +1,5 @@
+import 'cypress-plugin-xhr-toggle'
+
 import './commands/api_commands'
 import './commands/gui_commands'
 import './commands/session_login'

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
         "@faker-js/faker": "^7.6.0",
         "cypress": "^12.7.0",
+        "cypress-plugin-xhr-toggle": "^1.0.0",
         "esbuild": "^0.17.10",
         "snazzy": "^9.0.0",
         "standard": "^17.0.0"
@@ -1264,6 +1265,15 @@
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cypress-plugin-xhr-toggle": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cypress-plugin-xhr-toggle/-/cypress-plugin-xhr-toggle-1.0.0.tgz",
+      "integrity": "sha512-Ds9ww5D3Wcd9SQWRY+IzLmTqVzPH6804p9SdvHriA0XpmL8LmiM+a6ikYOclnZF87KpZEDswjAQvrl907Ny6RA==",
+      "dev": true,
+      "peerDependencies": {
+        "cypress": ">=10"
       }
     },
     "node_modules/dashdash": {
@@ -5554,6 +5564,13 @@
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       }
+    },
+    "cypress-plugin-xhr-toggle": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cypress-plugin-xhr-toggle/-/cypress-plugin-xhr-toggle-1.0.0.tgz",
+      "integrity": "sha512-Ds9ww5D3Wcd9SQWRY+IzLmTqVzPH6804p9SdvHriA0XpmL8LmiM+a6ikYOclnZF87KpZEDswjAQvrl907Ny6RA==",
+      "dev": true,
+      "requires": {}
     },
     "dashdash": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
     "@faker-js/faker": "^7.6.0",
     "cypress": "^12.7.0",
+    "cypress-plugin-xhr-toggle": "^1.0.0",
     "esbuild": "^0.17.10",
     "snazzy": "^9.0.0",
     "standard": "^17.0.0"


### PR DESCRIPTION
This PR adds a sample test that demonstrates the usage of the [`cy.session()`](https://docs.cypress.io/api/commands/session) command for multiple sessions inside the same test, allowing testing collaborative flows, such as GitLab users tagging and commenting on others inside issues.

Reference: [Switching sessions inside tests](https://docs.cypress.io/api/commands/session#Switching-sessions-inside-tests).