### PR TITLE
Add a GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,11 @@ jobs:
           name: Screenshots
           path: cypress/screenshots
           retention-days: 1
+
+      - name: Upload videos
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Screenshots
+          path: cypress/videos
+          retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: Screenshots
+          name: Video
           path: cypress/videos
           retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v5
         env:
-          CYPRESS_user_name: ${{ secrets.user_name }}
-          CYPRESS_user_password: ${{ secrets.user_password }}
+          CYPRESS_USER_NAME: ${{ secrets.USER_NAME }}
+          CYPRESS_USER_PASSWORD: ${{ secrets.USER_PASSWORD }}
         with:
           command: npm test
       
@@ -52,6 +52,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: Video
+          name: Videos
           path: cypress/videos
           retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: 'Cypress Tests Workflow'
+
+on:
+  pull_request:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+jobs:
+  static-analysis:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run Standard JS
+      run: npm run lint
+
+  cypress-tests:
+    needs: static-analysis
+    runs-on: ubuntu-latest
+    services:
+      gitlab-ce:
+        image: wlsf82/gitlab-ce:latest
+        ports:
+          - 80:80
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Cypress run
+        uses: cypress-io/github-action@v5
+        env:
+          CYPRESS_user_name: ${{ secrets.user_name }}
+          CYPRESS_user_password: ${{ secrets.user_password }}
+        with:
+          command: npm test
+      
+      - name: Upload screenshots
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Screenshots
+          path: cypress/screenshots
+          retention-days: 1

--- a/cypress.env.example.json
+++ b/cypress.env.example.json
@@ -1,4 +1,4 @@
 {
-  "user_name": "root",
-  "user_password": "53cR37-p@s5W0rd"
+  "USER_NAME": "root",
+  "USER_PASSWORD": "53cR37-p@s5W0rd"
 }

--- a/cypress/e2e/gui/admin/impersonateUser.cy.js
+++ b/cypress/e2e/gui/admin/impersonateUser.cy.js
@@ -52,6 +52,6 @@ describe('User impersonation', () => {
     // Assert
     cy.get('.dropdown-menu-right ul li.current-user')
       .should('contain', 'Administrator')
-      .and('contain', `@${Cypress.env('user_name')}`)
+      .and('contain', `@${Cypress.env('USER_NAME')}`)
   })
 })

--- a/cypress/e2e/gui/project/assignIssue.cy.js
+++ b/cypress/e2e/gui/project/assignIssue.cy.js
@@ -9,11 +9,11 @@ describe('Assign issue', () => {
   })
 
   it('assigns an issue to yourself', function () {
-    cy.visit(`${Cypress.env('user_name')}/${this.projectsBody[0].name}/issues/${this.issue.body.iid}`)
+    cy.visit(`${Cypress.env('USER_NAME')}/${this.projectsBody[0].name}/issues/${this.issue.body.iid}`)
 
     cy.contains('assign yourself').click()
 
-    cy.contains('.qa-assignee-block', `@${Cypress.env('user_name')}`)
+    cy.contains('.qa-assignee-block', `@${Cypress.env('USER_NAME')}`)
       .should('be.visible')
   })
 })

--- a/cypress/e2e/gui/project/closeIssue.cy.js
+++ b/cypress/e2e/gui/project/closeIssue.cy.js
@@ -9,7 +9,7 @@ describe('Close an issue', () => {
   })
 
   it('closes an issue successfully', function () {
-    cy.visit(`${Cypress.env('user_name')}/${this.projectsBody[0].name}/issues/${this.issue.body.iid}`)
+    cy.visit(`${Cypress.env('USER_NAME')}/${this.projectsBody[0].name}/issues/${this.issue.body.iid}`)
 
     cy.get('.d-none.btn-close').click()
 

--- a/cypress/e2e/gui/project/closeIssueQuickAction.cy.js
+++ b/cypress/e2e/gui/project/closeIssueQuickAction.cy.js
@@ -9,7 +9,7 @@ describe('Close an issue using quick action', () => {
   })
 
   it('closes an issue using a quick action successfully', function () {
-    cy.visit(`${Cypress.env('user_name')}/${this.projectsBody[0].name}/issues/${this.issue.body.iid}`)
+    cy.visit(`${Cypress.env('USER_NAME')}/${this.projectsBody[0].name}/issues/${this.issue.body.iid}`)
 
     cy.gui_commentOnIssue('/close ')
 

--- a/cypress/e2e/gui/project/commentOnIssue.cy.js
+++ b/cypress/e2e/gui/project/commentOnIssue.cy.js
@@ -13,7 +13,7 @@ describe('Comment on an Issue', () => {
   it('comments on an issue successfully', function () {
     const comment = faker.random.words(3)
 
-    cy.visit(`${Cypress.env('user_name')}/${this.projectsBody[0].name}/issues/${this.issue.body.iid}`)
+    cy.visit(`${Cypress.env('USER_NAME')}/${this.projectsBody[0].name}/issues/${this.issue.body.iid}`)
 
     cy.gui_commentOnIssue(comment)
 

--- a/cypress/e2e/gui/project/createNewFile.cy.js
+++ b/cypress/e2e/gui/project/createNewFile.cy.js
@@ -16,7 +16,7 @@ describe('Create new file', () => {
   })
 
   it('creates a new file successfully', () => {
-    cy.visit(`${Cypress.env('user_name')}/${project.name}/new/master`)
+    cy.visit(`${Cypress.env('USER_NAME')}/${project.name}/new/master`)
 
     cy.gui_createFile(project.file)
 

--- a/cypress/e2e/gui/project/createProject.cy.js
+++ b/cypress/e2e/gui/project/createProject.cy.js
@@ -14,7 +14,7 @@ describe('Create Project', () => {
 
     cy.gui_createProject(project)
 
-    cy.url().should('be.equal', `${Cypress.config('baseUrl')}${Cypress.env('user_name')}/${project.name}`)
+    cy.url().should('be.equal', `${Cypress.config('baseUrl')}${Cypress.env('USER_NAME')}/${project.name}`)
     cy.contains('h1', project.name).should('be.visible')
     cy.contains('p', project.description).should('be.visible')
   })

--- a/cypress/e2e/gui/project/createWiki.cy.js
+++ b/cypress/e2e/gui/project/createWiki.cy.js
@@ -12,12 +12,12 @@ describe('Create new page', () => {
   it('creates a wiki successfully', () => {
     const wikiContent = faker.random.words(4)
 
-    cy.visit(`${Cypress.env('user_name')}/${project.name}/wikis/home?view=create`)
+    cy.visit(`${Cypress.env('USER_NAME')}/${project.name}/wikis/home?view=create`)
 
     cy.get('.qa-wiki-content-textarea').type(wikiContent)
     cy.contains('Create page').click()
 
-    cy.url().should('be.equal', `${Cypress.config('baseUrl')}${Cypress.env('user_name')}/${project.name}/wikis/home`)
+    cy.url().should('be.equal', `${Cypress.config('baseUrl')}${Cypress.env('USER_NAME')}/${project.name}/wikis/home`)
     cy.contains('[data-qa-selector="wiki_page_content"]', wikiContent).should('be.visible')
   })
 })

--- a/cypress/e2e/gui/project/issueBoard.cy.js
+++ b/cypress/e2e/gui/project/issueBoard.cy.js
@@ -10,15 +10,15 @@ describe('Issue board', () => {
       .then(function ({ body }) {
         const { title, iid } = this.issue.body
 
-        cy.visit(`${Cypress.env('user_name')}/${body[0].name}/-/boards`)
+        cy.visit(`${Cypress.env('USER_NAME')}/${body[0].name}/-/boards`)
 
         cy.contains('[data-board-type="backlog"] [data-qa-selector="board_card"]', title)
           .should('be.visible')
 
-        cy.visit(`${Cypress.env('user_name')}/${body[0].name}/issues/${iid}`)
+        cy.visit(`${Cypress.env('USER_NAME')}/${body[0].name}/issues/${iid}`)
         cy.get('.d-none.btn-close').click()
 
-        cy.visit(`${Cypress.env('user_name')}/${body[0].name}/-/boards`)
+        cy.visit(`${Cypress.env('USER_NAME')}/${body[0].name}/-/boards`)
 
         cy.contains('[data-board-type="closed"] [data-qa-selector="board_card"]', title)
           .should('be.visible')

--- a/cypress/e2e/gui/project/issueMilestone.cy.js
+++ b/cypress/e2e/gui/project/issueMilestone.cy.js
@@ -13,7 +13,7 @@ describe('Issue milestone', () => {
         const issueIid = this.issue.body.iid
 
         cy.api_createProjectMilestone(project.id, milestone)
-        cy.visit(`${Cypress.env('user_name')}/${project.name}/issues/${issueIid}`)
+        cy.visit(`${Cypress.env('USER_NAME')}/${project.name}/issues/${issueIid}`)
       })
   })
 

--- a/cypress/e2e/gui/project/labelAnIssue.cy.js
+++ b/cypress/e2e/gui/project/labelAnIssue.cy.js
@@ -16,7 +16,7 @@ describe('Label an issue', () => {
         const issueIid = this.issue.body.iid
 
         cy.api_createProjectLabel(project.id, label)
-        cy.visit(`${Cypress.env('user_name')}/${project.name}/issues/${issueIid}`)
+        cy.visit(`${Cypress.env('USER_NAME')}/${project.name}/issues/${issueIid}`)
       })
   })
 

--- a/cypress/e2e/gui/project/multipleUsersInAnProject.cy.js
+++ b/cypress/e2e/gui/project/multipleUsersInAnProject.cy.js
@@ -1,6 +1,6 @@
 const newUser = require('../../../fixtures/sampleUser')
 const { username: newUserName, password: newUserPassword } = newUser
-const defaultUser = Cypress.env('user_name')
+const defaultUser = Cypress.env('USER_NAME')
 
 describe('Project with multiple users', () => {
   beforeEach(() => {

--- a/cypress/e2e/gui/project/reopenClosedIssue.cy.js
+++ b/cypress/e2e/gui/project/reopenClosedIssue.cy.js
@@ -5,7 +5,7 @@ describe('Reopen a closed issue', () => {
     cy.api_createIssue().as('issue')
     cy.api_getAllProjects()
       .then(function ({ body }) {
-        cy.visit(`${Cypress.env('user_name')}/${body[0].name}/issues/${this.issue.body.iid}`)
+        cy.visit(`${Cypress.env('USER_NAME')}/${body[0].name}/issues/${this.issue.body.iid}`)
         cy.get('.d-none.btn-close').click()
       })
   })

--- a/cypress/support/commands/gui_commands.js
+++ b/cypress/support/commands/gui_commands.js
@@ -1,8 +1,8 @@
 import { faker } from '@faker-js/faker/locale/en'
 
 Cypress.Commands.add('gui_login', (
-  username = Cypress.env('user_name'),
-  password = Cypress.env('user_password')
+  username = Cypress.env('USER_NAME'),
+  password = Cypress.env('USER_PASSWORD')
 ) => {
   cy.visit('users/sign_in')
 
@@ -14,8 +14,8 @@ Cypress.Commands.add('gui_login', (
 })
 
 Cypress.Commands.add('gui_login_or_signup_and_login', (
-  username = Cypress.env('user_name'),
-  password = Cypress.env('user_password')
+  username = Cypress.env('USER_NAME'),
+  password = Cypress.env('USER_PASSWORD')
 ) => {
   cy.visit('')
 
@@ -28,7 +28,7 @@ Cypress.Commands.add('gui_login_or_signup_and_login', (
   cy.gui_login(username, password)
 })
 
-Cypress.Commands.add('signup', (password = Cypress.env('user_password')) => {
+Cypress.Commands.add('signup', (password = Cypress.env('USER_PASSWORD')) => {
   cy.get('[data-qa-selector="password_field"]').type(password, { log: false })
   cy.get('[data-qa-selector="password_confirmation_field"]').type(password, { log: false })
   cy.get('[data-qa-selector="change_password_button"]').click()
@@ -81,7 +81,7 @@ Cypress.Commands.add('gui_createProject', project => {
 })
 
 Cypress.Commands.add('gui_createIssue', (project, issue) => {
-  cy.visit(`${Cypress.env('user_name')}/${project.name}/issues/new`)
+  cy.visit(`${Cypress.env('USER_NAME')}/${project.name}/issues/new`)
 
   cy.get('.qa-issuable-form-title').type(issue.title)
   cy.get('.qa-issuable-form-description').type(issue.description)
@@ -126,7 +126,7 @@ Cypress.Commands.add('gui_removeGroup', ({ name, path }) => {
 })
 
 Cypress.Commands.add('gui_createProjectMilestone', (project, milestone) => {
-  cy.visit(`${Cypress.env('user_name')}/${project.name}/-/milestones/new`)
+  cy.visit(`${Cypress.env('USER_NAME')}/${project.name}/-/milestones/new`)
 
   cy.get('.qa-milestone-title').type(milestone.title)
   cy.get('.qa-milestone-create-button').click()
@@ -162,7 +162,7 @@ Cypress.Commands.add('gui_createFile', file => {
 Cypress.Commands.add('gui_addUserToProject', (user, project) => {
   const { username } = user
 
-  cy.visit(`${Cypress.env('user_name')}/${project}/-/project_members`)
+  cy.visit(`${Cypress.env('USER_NAME')}/${project}/-/project_members`)
   cy.contains('label', 'GitLab member or Email address')
     .next()
     .type(`@${username}`)

--- a/cypress/support/commands/session_login.js
+++ b/cypress/support/commands/session_login.js
@@ -1,6 +1,6 @@
 Cypress.Commands.add('sessionLogin', (
-  user = Cypress.env('user_name'),
-  password = Cypress.env('user_password')
+  user = Cypress.env('USER_NAME'),
+  password = Cypress.env('USER_PASSWORD')
 ) => {
   const login = () => cy.gui_login_or_signup_and_login(user, password)
 


### PR DESCRIPTION
Implementação de workflow do GitHub Actions com 2 jobs:
1.  static-analysis - executa a análise estática do Standard JS através do script 'npm run lint'
2.  cypress-tests - executa todos os testes através do script 'npm test'

Adicionados os seguintes triggers: 
1.  pull_request pro branch "main"
2.  workflow_dispatch - permite a execução manual através da aba Actions

Adicionado o step de Upload screenshots (que só é executado em caso de falha) - bastante útil para análise de falhas.

No setup do ambiente optei por usar a imagem Docker do GitLab CE como um container de serviço. É um setup consideravelmente demorado dada a complexidade da imagem, mas é uma opção válida.

**Nota:** é necessário criar as secrets "user_name" e "password" no repositório para execução em ambiente de CI.

**Observação:** notei alguns testes com comportamente flaky na suíte (que inclusive falharam na execução local em modo headless), porém ainda não pude analisá-los:

-   removes a group successfully
- sets, edits and clears user status
- users reply to each other in an issue