### PR TITLE
Enable a bit of parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Run Standard JS
       run: npm run lint
 
-  cypress-tests:
+  api-cypress-tests:
     needs: static-analysis
     runs-on: ubuntu-latest
     services:
@@ -42,8 +42,82 @@ jobs:
           CYPRESS_user_password: ${{ secrets.CYPRESS_user_password }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
         with:
-          command: npm run test:cloud
-      
+          command: npm run test:api:cloud
+
+      - name: Upload screenshots
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Screenshots
+          path: cypress/screenshots
+          retention-days: 1
+
+      - name: Upload videos
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Videos
+          path: cypress/videos
+          retention-days: 1
+
+  gui-project-cypress-tests:
+    needs: static-analysis
+    runs-on: ubuntu-latest
+    services:
+      gitlab-ce:
+        image: wlsf82/gitlab-ce:latest
+        ports:
+          - 80:80
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Cypress run
+        uses: cypress-io/github-action@v5
+        env:
+          CYPRESS_user_name: ${{ secrets.CYPRESS_user_name }}
+          CYPRESS_user_password: ${{ secrets.CYPRESS_user_password }}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+        with:
+          command: npm run test:gui:project:cloud
+
+      - name: Upload screenshots
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Screenshots
+          path: cypress/screenshots
+          retention-days: 1
+
+      - name: Upload videos
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Videos
+          path: cypress/videos
+          retention-days: 1
+
+  gui-all-but-project-cypress-tests:
+    needs: static-analysis
+    runs-on: ubuntu-latest
+    services:
+      gitlab-ce:
+        image: wlsf82/gitlab-ce:latest
+        ports:
+          - 80:80
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Cypress run
+        uses: cypress-io/github-action@v5
+        env:
+          CYPRESS_user_name: ${{ secrets.CYPRESS_user_name }}
+          CYPRESS_user_password: ${{ secrets.CYPRESS_user_password }}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+        with:
+          command: npm run test:gui:all:but:project:cloud
+
       - name: Upload screenshots
         if: failure()
         uses: actions/upload-artifact@v3

--- a/cypress/e2e/gui/index.cy.js
+++ b/cypress/e2e/gui/index.cy.js
@@ -1,7 +1,7 @@
 // Setup - Sign in (or Sign up) and create an access token
 import '../gui/profile/createAccessToken.cy'
 
-// GUI tests
+// GUI tests (all but project)
 import './admin/broadcastMessage.cy'
 // The below test destroys the user session. The next one recreates it.
 import './admin/impersonateUser.cy.js'
@@ -10,20 +10,6 @@ import './group/createGroupLabel.cy'
 import './group/removeGroup.cy.js'
 import './group/subGroup.cy'
 import './profile/setStatus.cy.js'
-import './project/assignIssue.cy'
-import './project/closeIssue.cy'
-import './project/closeIssueQuickAction.cy'
-import './project/commentOnIssue.cy'
-import './project/createIssue.cy'
-import './project/createNewFile.cy'
-import './project/createProject.cy'
-import './project/createProjectMilestone.cy'
-import './project/createWiki.cy'
-import './project/issueBoard.cy'
-import './project/issueMilestone.cy'
-import './project/labelAnIssue.cy'
-import './project/reopenClosedIssue.cy'
-import './project/multipleUsersInAnProject.cy.js'
 import './snippets/createSnippet.cy.js'
 import './authentication/loginAsNonDefaultUser.cy'
 

--- a/cypress/e2e/gui/project/index.cy.js
+++ b/cypress/e2e/gui/project/index.cy.js
@@ -1,0 +1,21 @@
+// Setup - Sign in (or Sign up) and create an access token
+import '../profile/createAccessToken.cy'
+
+// GUI tests (project)
+import './assignIssue.cy'
+import './closeIssue.cy'
+import './closeIssueQuickAction.cy'
+import './commentOnIssue.cy'
+import './createIssue.cy'
+import './createNewFile.cy'
+import './createProject.cy'
+import './createProjectMilestone.cy'
+import './createWiki.cy'
+import './issueBoard.cy'
+import './issueMilestone.cy'
+import './labelAnIssue.cy'
+import './reopenClosedIssue.cy'
+import './multipleUsersInAnProject.cy.js'
+
+// Teardown - Delete access token(s)
+import '../profile/deleteAccessTokens.cy'

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
     "cy:open": "cypress open",
     "lint": "standard --verbose | snazzy",
     "lint:fix": "standard --fix",
-    "test": "npm run test:api && npm run test:gui",
-    "test:cloud": "cypress run --record --tag 'api' --spec 'cypress/e2e/api/index.cy.js' && cypress run --record --tag 'gui' --spec 'cypress/e2e/gui/index.cy.js'",
+    "test:api:cloud": "cypress run --record --tag 'api' --spec 'cypress/e2e/api/index.cy.js'",
+    "test:gui:project:cloud": "cypress run --record --tag 'gui:project' --spec 'cypress/e2e/gui/project/index.cy.js'",
+    "test:gui:all:but:project:cloud": "cypress run --record --tag 'gui:all:but:project' --spec 'cypress/e2e/gui/index.cy.js'",
     "test:api": "cypress run --spec 'cypress/e2e/api/index.cy.js'",
-    "test:gui": "cypress run --spec 'cypress/e2e/gui/index.cy.js'"
+    "test:gui:project": "cypress run --spec 'cypress/e2e/gui/project/index.cy.js'",
+    "test:gui:all:but:project": "cypress run --spec 'cypress/e2e/gui/index.cy.js'"
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
This PR shortens the time it takes for all tests to run by parallelizing API, GUI Project-related, and GUI Project-not-related tests.

> The `Project with multiple users - users reply to each other in an issue` test is still quite slow, but that's an improvement for another PR.